### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Custom style sheets for [IPython Notebook][1], using Chris Kempson's [Base16][2]
 
 ## Screenshots
 
-####Ocean dark
+#### Ocean dark
 
 ![ocean dark theme screenshot](./screenshots/ocean-dark.png "Ocean dark")
 
-####Solarized light
+#### Solarized light
 
 ![solarized light theme screenshot](./screenshots/solarized-light.png "Solarized light")
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
